### PR TITLE
option did not update it self on save

### DIFF
--- a/acf-subfield-chooser-v5.php
+++ b/acf-subfield-chooser-v5.php
@@ -189,9 +189,9 @@ class acf_field_subfield_chooser extends acf_field {
 							if ($k1 == $field['subfield_name']) {
 
 								if ($field['data_type']) {
-									echo '<option value="' . $k . '"'.selected($field['value'], $v[$field['Other_subfield_name']], false).'>' . $v1 . '</option>';
+									echo '<option value="' . $k . '"'.selected($field['value'], $k, false).'>' . $v1 . '</option>';
 								} else {
-									echo '<option value="' . sanitize_title($v[$field['Other_subfield_name']]) . '"'.selected($field['value'], sanitize_title($v[$field['Other_subfield_name']]), false).'>' . $v1 . '</option>';
+									echo '<option value="' . sanitize_title($v[$field['Other_subfield_name']]) . '"'.selected($field['value'], $k), false).'>' . $v1 . '</option>';
 								}
 															}
 						}


### PR DESCRIPTION
select option did not update it self on save,  so on next save the the first option of the select was set as value. 

problem:
selected() evaluated the key against the value of the subfield, now it compares keys.

Keep up the good work!
